### PR TITLE
Restore compilation of unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ sofa_create_package_with_targets(
 # If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
 cmake_dependent_option(COSSERATPLUGIN_BUILD_TESTS "Compile the tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
 if(COSSERATPLUGIN_BUILD_TESTS)
-    add_subdirectory(tests)
+    add_subdirectory(Tests)
 endif()
 
 include(cmake/packaging.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ sofa_create_package_with_targets(
 
 # Tests
 # If SOFA_BUILD_TESTS exists and is OFF, then these tests will be auto-disabled
-cmake_dependent_option(COSSERATPLUGIN_BUILD_TESTS "Compile the tests" OFF "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
+cmake_dependent_option(COSSERATPLUGIN_BUILD_TESTS "Compile the tests" ON "SOFA_BUILD_TESTS OR NOT DEFINED SOFA_BUILD_TESTS" OFF)
 if(COSSERATPLUGIN_BUILD_TESTS)
     add_subdirectory(tests)
 endif()

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -5,7 +5,7 @@ set(This Cosserat.Tests)
 project(${This} C CXX)
 
 #find_package(CosseratPlugin REQUIRED)
-find_package(SofaTest REQUIRED)
+find_package(Sofa.Testing REQUIRED)
 
 enable_testing()
 
@@ -24,8 +24,7 @@ set(SOURCE_FILES
 add_executable(${This} ${SOURCE_FILES} ${HEADER_FILES})
 
 target_link_libraries(${PROJECT_NAME} 
-        SofaTest 
-        gtest
+        Sofa.Testing
         CosseratPlugin
 )
 

--- a/Tests/constraint/CosseratUnilateralInteractionConstraintTest.cpp
+++ b/Tests/constraint/CosseratUnilateralInteractionConstraintTest.cpp
@@ -49,9 +49,7 @@ struct CosseratUnilateralInteractionConstraintTest : public NumericTest<>
         fprintf(stderr, "Starting up ! \n");
         x = new int(42);
 
-        sofa::simpleapi::importPlugin("SofaComponentAll");
-        sofa::simpleapi::importPlugin("SofaMiscCollision");
-        sofa::simpleapi::importPlugin("SofaOpenglVisual");
+        sofa::simpleapi::importPlugin("Sofa.Component");
         sofa::simpleapi::importPlugin("CosseratPlugin");
 
         //create the context for

--- a/Tests/forcefield/BeamHookeLawForceFieldTest.cpp
+++ b/Tests/forcefield/BeamHookeLawForceFieldTest.cpp
@@ -2,27 +2,24 @@
 // Created by younes on 07/06/2021.
 //
 
-#include "../../src/config.h"
+#include <CosseratPlugin/config.h>
 
-DISABLE_ALL_WARNINGS_BEGIN
 #include <gtest/gtest.h>
 #include <sofa/testing/BaseTest.h>
-#include <SofaTest/Sofa_test.h>
 #include <sofa/defaulttype/config.h>
 #include <sofa/simulation/Simulation.h>
 #include <sofa/simulation/Node.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
-#include <SofaSimulationGraph/DAGSimulation.h>
+#include <sofa/component/statecontainer/MechanicalObject.h>
+#include <sofa/simulation/graph/DAGSimulation.h>
 
-#include <SofaSimulationGraph/SimpleApi.h>
-#include <SofaSimulationCommon/SceneLoaderXML.h>
+#include <sofa/simulation/graph/SimpleApi.h>
+#include <sofa/simulation/common/SceneLoaderXML.h>
 #include <sofa/helper/logging/Message.h>
 #include <sofa/core/behavior/ForceField.inl>
 #include <sofa/helper/system/PluginManager.h>
-DISABLE_ALL_WARNINGS_END
 
-#include "../../src/forcefield/BeamHookeLawForceField.h"
-#include "../../src/forcefield/BeamHookeLawForceField.inl"
+#include <CosseratPlugin/forcefield/BeamHookeLawForceField.inl>
+#include <sofa/testing/NumericTest.h>
 
 using sofa::testing::BaseTest ;
 using testing::Test;
@@ -32,7 +29,7 @@ using namespace sofa::simpleapi;
 namespace sofa {
 
 template <typename _DataTypes>
-struct BeamHookeLawForceFieldTest : public NumericTest<> {
+struct BeamHookeLawForceFieldTest : public testing::NumericTest<> {
     typedef _DataTypes DataTypes;
     typedef typename DataTypes::VecCoord VecCoord;
     typedef typename DataTypes::VecDeriv VecDeriv;
@@ -47,9 +44,7 @@ struct BeamHookeLawForceFieldTest : public NumericTest<> {
     void SetUp() override {
         // initialization or some code to run before each test
         fprintf(stderr, "Starting up ! \n");
-        sofa::simpleapi::importPlugin("SofaComponentAll");
-        sofa::simpleapi::importPlugin("SofaMiscCollision");
-        sofa::simpleapi::importPlugin("SofaOpenglVisual");
+        sofa::simpleapi::importPlugin("Sofa.Component");
         sofa::simpleapi::importPlugin("CosseratPlugin");
 
         //create the context for
@@ -159,8 +154,7 @@ void BeamHookeLawForceFieldTest<defaulttype::Vec3Types>::basicAttributesTest(){
              "   </Node>                                                                    \n" ;
 
     Node::SPtr root = SceneLoaderXML::loadFromMemory ("testscene",
-                                                      scene.str().c_str(),
-                                                      scene.str().size()) ;
+                                                      scene.str().c_str()) ;
 
     EXPECT_NE(root.get(), nullptr) ;
     root->init(sofa::core::execparams::defaultInstance()) ;


### PR DESCRIPTION
All plugins usually have their automatic tests enabled by default. It was not the case for Cosserat.
Moreover, tests relied on old modules such as SofaTest. It has been updated with the new architecture.
Unfortunately, the tests are failing...